### PR TITLE
Oooh, streamable finite arithmetic sequences!

### DIFF
--- a/lib/sequence.ex
+++ b/lib/sequence.ex
@@ -1,0 +1,20 @@
+defmodule Sequence do
+  @moduledoc """
+  Streamable arithmetic sequences
+  """
+
+  def find_term(term_to_find, first_term, common_difference) do
+    first_term + (term_to_find - 1) * common_difference
+  end
+
+  def finite_lazy(num_terms, first_term, last_term) do
+    common_difference = common_difference(num_terms, first_term, last_term)
+    f = &(Sequence.find_term(&1, first_term, common_difference))
+    Stream.map(1..num_terms, f)
+  end
+
+  defp common_difference(1, first_term, last_term), do: last_term - first_term
+  defp common_difference(num_terms, first_term, last_term) do
+    (last_term - first_term) / (num_terms - 1)
+  end
+end

--- a/test/sequence_test.exs
+++ b/test/sequence_test.exs
@@ -1,0 +1,32 @@
+defmodule SequenceTest do
+  use ExUnit.Case
+
+  test "#find_term: returns the nth term in a sequence" do
+    assert Sequence.find_term(1, 0, 1) == 0
+    assert Sequence.find_term(2, 0, 1) == 1
+    assert Sequence.find_term(3, 0, 1) == 2
+
+    assert Sequence.find_term(1, 1, 1) == 1
+    assert Sequence.find_term(2, 1, 1) == 2
+    assert Sequence.find_term(3, 1, 1) == 3
+  end
+
+  test "#finite_lazy: is a lazy finite sequence with n terms " <>
+       "within a defined range" do
+    assert Enum.to_list(Sequence.finite_lazy(1, 1, 1)) == [1]
+    assert Enum.to_list(Sequence.finite_lazy(2, 1, 2)) == [1, 2]
+    assert Enum.to_list(Sequence.finite_lazy(4, 1, 4)) == [1, 2, 3, 4]
+
+    assert Enum.to_list(Sequence.finite_lazy(3, -1.5, 1.5)) == [-1.5, 0.0, 1.5]
+
+    floater = Enum.to_list(Sequence.finite_lazy(16, -1.5, 1.5))
+    assert floater |> List.first == -1.5
+    assert floater |> List.last == 1.5
+    assert floater |> Enum.count == 16
+
+    big_floater = Enum.to_list(Sequence.finite_lazy(800, -1.5, 1.5))
+    assert big_floater |> List.first == -1.5
+    assert big_floater |> List.last == 1.5
+    assert big_floater |> Enum.count == 800
+  end
+end


### PR DESCRIPTION
---
### Your help please :)
- Does this seem like "good Elixir" (a subjective moving target I know)?
- Is it easy to read and understand?
- How might I improve this?
- Is anything interesting enough to warrant a blog post?
- Does the explanation make sense?

---
### Background

For the Mandelbrot fractal algorithm we need to be able to iterate over sequences of real numbers. Between -1.5 and 1.5 for example.

E.g. if we are trying to generate an image that is 800px wide then we would need to divide that range into 800 steps (terms).
### Problems with the floating point number type

To keep things simple I'm sticking with floating point, which has known precision problems due to the fact that it [can only approximate certain numbers](https://en.wikipedia.org/wiki/Floating_point#Representable_numbers.2C_conversion_and_rounding) when they cannot be precisely represented in base-2. A notable problem example being 0.1, but in general common base-10 values such as 0.5 are also effected.

We don't need absolute precision for this project, but I do want to avoid accruing excessive floating point error.
### A disappointing solution

Solutions based on repeatedly adding an incremental value to a starting value tend to compound error on top of error. Resulting in never reaching the final value in the range. E.g. adding 0.1 to 0, 10 times:

``` elixir
iex(1)> Enum.reduce(1..10, [0], fn(_x, acc) -> [hd(acc) + 0.1 | acc] end) |> Enum.reverse
[0,
 0.1,
 0.2,
 0.30000000000000004,
 0.4,
 0.5,
 0.6,
 0.7,
 0.7999999999999999,
 0.8999999999999999,
 0.9999999999999999] # We don't arrive at 1.0 !!!
```
### A less disappointing, nearly joyful solution

A better way to do it is to use [a formula that calculates each term in the sequence](http://www.regentsprep.org/regents/math/algtrig/atp2/arithseq.htm). This results in more terms evaluating to values we expect (or at least nearer approximations). Presumably this is because it minimises the number of operations required to derive a term from the starting value and thus less error is introduced. Importantly we do arrive at the last term in the sequence.

E.g. using the code here we get this result when adding 0.1 to 0.0 10 times (note 11 terms requested because the first term 0 must also be calculated):

``` elixir
iex(1)> {num_terms, first_term, last_term} = {11, 0.0, 1.0}
iex(2)> Sequence.finite_lazy(num_terms, first_term, last_term) |> Enum.to_list
[0.0,
 0.1, # Approximation being hidden here, see below (*)
 0.2,
 0.30000000000000004, # Sometimes it leaks out
 0.4,
 0.5,
 0.6000000000000001,
 0.7000000000000001,
 0.8,
 0.9,
 1.0] # But we do arrive at 1.0 :)
```

(*) Common base-10 numbers being treated specially, most likely by the formatting routines.

``` elixir
iex(1)> 0.1
0.1
iex(2)> Float.to_string(0.1, decimals: 20)
"0.10000000000000000555" # Oooh you can't hide forever!
```
