### PR TITLE
Mandelbrot set calculations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /_build
 /cover
 /deps
+/doc
 erl_crash.dump
 *.ez
 mix.lock

--- a/lib/complex.ex
+++ b/lib/complex.ex
@@ -17,7 +17,7 @@ defmodule Complex do
     new(a.re - b.re, a.im - b.im)
   end
 
-  def mult(a = %__MODULE__{}, b = %__MODULE__{}) do
+  def multiply(a = %__MODULE__{}, b = %__MODULE__{}) do
     re = (a.re * b.re) + (a.im * b.im * -1)
     im = (a.re * b.im) + (b.re * a.im)
     new(re, im)

--- a/lib/complex.ex
+++ b/lib/complex.ex
@@ -4,7 +4,6 @@ defmodule Complex do
   """
   defstruct re: 0, im: 0
 
-  def new({re, im}), do: new(re, im)
   def new(re, im) when is_number(re) and is_number(im) do
     %__MODULE__{re: re, im: im}
   end

--- a/lib/mandelbrot_set.ex
+++ b/lib/mandelbrot_set.ex
@@ -17,4 +17,26 @@ defmodule MandelbrotSet do
     z_squared = Complex.multiply(z, z)
     Complex.add(z_squared, c)
   end
+
+  @doc """
+  Given a complex constant `c`, this function starts with `z = 0` and
+  iteratively calls `apply_polynomial(z, c)` to calculate the next `z` value.
+
+  It stops when `f_stop_iterating` returns true.
+
+  It returns the number of iterations reached before `f_stop_iterating`
+  returned true.
+  """
+  def iterate_until(c, f_stop_iterating) do
+    do_iterate_until(c, Complex.new(0.0, 0.0), 0, f_stop_iterating)
+  end
+
+  defp do_iterate_until(c, z, iteration_count, f_stop_iterating) do
+    if f_stop_iterating.(z, iteration_count) do
+      iteration_count
+    else
+      z_next = apply_polynomial(z, c)
+      do_iterate_until(c, z_next, iteration_count + 1, f_stop_iterating)
+    end
+  end
 end

--- a/lib/mandelbrot_set.ex
+++ b/lib/mandelbrot_set.ex
@@ -39,4 +39,16 @@ defmodule MandelbrotSet do
       do_iterate_until(c, z_next, iteration_count + 1, f_stop_iterating)
     end
   end
+
+  @doc """
+  A predicate to check if the value of z has exceeded the limit known to
+  characterise a value within the Mandelbrot set.
+
+  If |z| has exceeded 2 we know for sure that the sequence being calculated is
+  unbounded and will tend towards infinity. Numbers within the Mandelbrot set
+  tend towards 2 as you continue to iterate, but never exceed it.
+  """
+  def unbounded?(z) do
+    Complex.mod(z) > 2
+  end
 end

--- a/lib/mandelbrot_set.ex
+++ b/lib/mandelbrot_set.ex
@@ -10,6 +10,19 @@ defmodule MandelbrotSet do
   """
 
   @doc """
+  Given a complex number `c`, returns the number of iterations needed to prove
+  whether it is a member of the Mandelbrot set, up to a maximum of
+  `max_iterations`.
+  """
+  def count_iterations(c, max_iterations) do
+    should_stop? = fn (z, iteration_count) ->
+      iteration_count >= max_iterations or unbounded?(z)
+    end
+
+    iterate_until(c, should_stop?)
+  end
+
+  @doc """
   Implements the complex quadratic polynomial that is at the heart of the
   Mandelbrot set: `f(Z): Z^2 + C`
   """

--- a/lib/mandelbrot_set.ex
+++ b/lib/mandelbrot_set.ex
@@ -1,0 +1,20 @@
+defmodule MandelbrotSet do
+  @moduledoc """
+  This module provides functions to determine if a given complex constant,
+  (usually denoted as `C`) is a member of the Mandelbrot set.
+
+  ## Background information
+
+  * https://en.wikipedia.org/wiki/Mandelbrot_set
+  * http://stackoverflow.com/questions/425953/how-to-program-a-fractal
+  """
+
+  @doc """
+  Implements the complex quadratic polynomial that is at the heart of the
+  Mandelbrot set: `f(Z): Z^2 + C`
+  """
+  def apply_polynomial(z, c) do
+    z_squared = Complex.multiply(z, z)
+    Complex.add(z_squared, c)
+  end
+end

--- a/lib/sequence.ex
+++ b/lib/sequence.ex
@@ -1,0 +1,20 @@
+defmodule Sequence do
+  @moduledoc """
+  Streamable arithmetic sequences
+  """
+
+  def find_term(term_to_find, first_term, common_difference) do
+    first_term + (term_to_find - 1) * common_difference
+  end
+
+  def finite_lazy(num_terms, first_term, last_term) do
+    common_difference = common_difference(num_terms, first_term, last_term)
+    f = &(Sequence.find_term(&1, first_term, common_difference))
+    Stream.map(1..num_terms, f)
+  end
+
+  defp common_difference(1, first_term, last_term), do: last_term - first_term
+  defp common_difference(num_terms, first_term, last_term) do
+    (last_term - first_term) / (num_terms - 1)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,9 @@ defmodule Mandelbrot.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:dogma, "~> 0.0", only: :dev}
+      {:dogma, "~> 0.0", only: :dev},
+      {:earmark, "~> 0.1", only: :dev},
+      {:ex_doc, "~> 0.11", only: :dev}
     ]
   end
 end

--- a/test/complex_test.exs
+++ b/test/complex_test.exs
@@ -9,45 +9,41 @@ defmodule ComplexTest do
     assert z.im == 2
   end
 
-  test "can be created from a 2-tuple of real and imaginary parts" do
-    assert Complex.new(1, 2) == Complex.new({1, 2})
-  end
-
   test "cannot be created with non-numeric parts" do
     assert_raise FunctionClauseError, fn ->
-      {:not_a_number, 1} |> Complex.new
+      Complex.new(:not_a_number, 1)
     end
     assert_raise FunctionClauseError, fn ->
-      {1, :not_a_number} |> Complex.new
+      Complex.new(1, :not_a_number)
     end
     assert_raise FunctionClauseError, fn ->
-      {:not_a_number, "also not a number"} |> Complex.new
+      Complex.new(:not_a_number, "also not a number")
     end
   end
 
   test "two can be added together" do
     a = Complex.new(1, 2)
     b = Complex.new(1, 2)
-    assert a |> Complex.add(b) == Complex.new(2, 4)
+    assert Complex.add(a, b) == Complex.new(2, 4)
   end
 
   test "two can be subtracted" do
     a = Complex.new(3, 4)
     b = Complex.new(1, 1)
-    assert a |> Complex.subtract(b) == Complex.new(2, 3)
+    assert Complex.subtract(a, b) == Complex.new(2, 3)
   end
 
   test "can be multiplied" do
     a = Complex.new(2, -7)
     b = Complex.new(3, 2)
-    assert a |> Complex.multiply(b) == Complex.new(20, -17)
+    assert Complex.multiply(a, b) == Complex.new(20, -17)
   end
 
   test "the magnitude can be calculated" do
-    assert {1, 1} |> Complex.new |> Complex.mod == :math.sqrt(2)
-    assert {-3, 4} |> Complex.new |> Complex.mod == 5
+    assert Complex.new(1, 1) |> Complex.mod == :math.sqrt(2)
+    assert Complex.new(-3, 4) |> Complex.mod == 5
 
-    result = {-1, :math.sqrt(3)} |> Complex.new |> Complex.mod
+    result = Complex.new(-1, :math.sqrt(3)) |> Complex.mod
     assert_in_delta result, 2, @epsilon
   end
 end

--- a/test/complex_test.exs
+++ b/test/complex_test.exs
@@ -40,10 +40,10 @@ defmodule ComplexTest do
   end
 
   test "the magnitude can be calculated" do
-    assert Complex.new(1, 1) |> Complex.mod == :math.sqrt(2)
-    assert Complex.new(-3, 4) |> Complex.mod == 5
+    assert Complex.mod(Complex.new(1, 1)) == :math.sqrt(2)
+    assert Complex.mod(Complex.new(-3, 4)) == 5
 
-    result = Complex.new(-1, :math.sqrt(3)) |> Complex.mod
+    result = Complex.mod(Complex.new(-1, :math.sqrt(3)))
     assert_in_delta result, 2, @epsilon
   end
 end

--- a/test/complex_test.exs
+++ b/test/complex_test.exs
@@ -40,7 +40,7 @@ defmodule ComplexTest do
   test "can be multiplied" do
     a = Complex.new(2, -7)
     b = Complex.new(3, 2)
-    assert a |> Complex.mult(b) == Complex.new(20, -17)
+    assert a |> Complex.multiply(b) == Complex.new(20, -17)
   end
 
   test "the magnitude can be calculated" do

--- a/test/mandelbrot_set_test.exs
+++ b/test/mandelbrot_set_test.exs
@@ -2,6 +2,14 @@ defmodule MandelbrotSetTest do
   use ExUnit.Case
   @epsilon 0.1e-14
 
+  test "#count_iterations: counts until max_iterations or" do
+    not_in_the_set = Complex.new(1, 0)
+    in_the_set = Complex.new(-1, 0)
+
+    assert MandelbrotSet.count_iterations(not_in_the_set, 100) == 3
+    assert MandelbrotSet.count_iterations(in_the_set, 100) == 100
+  end
+
   test "#apply_polynomial" do
     z = Complex.new(1, 1)
     c = Complex.new(1, 1)

--- a/test/mandelbrot_set_test.exs
+++ b/test/mandelbrot_set_test.exs
@@ -6,4 +6,24 @@ defmodule MandelbrotSetTest do
     c = Complex.new(1, 1)
     assert MandelbrotSet.apply_polynomial(z, c) == Complex.new(1, 3)
   end
+
+  test "#iterate_until: iterates until `stop_iterating` returns true" do
+    c = Complex.new(1, 1)
+    stop_iterating = fn (_z, _iteration_count) -> true end
+
+    assert MandelbrotSet.iterate_until(c, stop_iterating) == 0
+    assert MandelbrotSet.iterate_until(c, stop_iterating) == 0
+  end
+
+  test "#iterate_until: returns the number of iterations reached" do
+    c = Complex.new(1, 1)
+    stop_iterating = fn (_z, iteration_count, max_iterations) ->
+      iteration_count >= max_iterations
+    end
+    stop_at_1 = &(stop_iterating.(&1, &2, 1))
+    stop_at_2 = &(stop_iterating.(&1, &2, 2))
+
+    assert MandelbrotSet.iterate_until(c, stop_at_1) == 1
+    assert MandelbrotSet.iterate_until(c, stop_at_2) == 2
+  end
 end

--- a/test/mandelbrot_set_test.exs
+++ b/test/mandelbrot_set_test.exs
@@ -1,5 +1,6 @@
 defmodule MandelbrotSetTest do
   use ExUnit.Case
+  @epsilon 0.1e-14
 
   test "#apply_polynomial" do
     z = Complex.new(1, 1)
@@ -25,5 +26,22 @@ defmodule MandelbrotSetTest do
 
     assert MandelbrotSet.iterate_until(c, stop_at_1) == 1
     assert MandelbrotSet.iterate_until(c, stop_at_2) == 2
+  end
+
+  test "#unbounded?: returns true if absolute value of z is greater than 2" do
+    # Evaluates to the smallest amount less than 2
+    bounded = Complex.new(2 - @epsilon, 0)
+    assert bounded |> Complex.mod <= 2
+    refute bounded |> MandelbrotSet.unbounded?
+
+    # Evaluates to 2 exactly
+    bounded = Complex.new(2, 0)
+    assert bounded |> Complex.mod <= 2
+    refute bounded |> MandelbrotSet.unbounded?
+
+    # Evaluates to the smallest amount greater than 2
+    unbounded = Complex.new(2 + @epsilon, 0)
+    assert unbounded |> Complex.mod > 2
+    assert unbounded |> MandelbrotSet.unbounded?
   end
 end

--- a/test/mandelbrot_set_test.exs
+++ b/test/mandelbrot_set_test.exs
@@ -1,0 +1,9 @@
+defmodule MandelbrotSetTest do
+  use ExUnit.Case
+
+  test "#apply_polynomial" do
+    z = Complex.new(1, 1)
+    c = Complex.new(1, 1)
+    assert MandelbrotSet.apply_polynomial(z, c) == Complex.new(1, 3)
+  end
+end

--- a/test/sequence_test.exs
+++ b/test/sequence_test.exs
@@ -1,0 +1,32 @@
+defmodule SequenceTest do
+  use ExUnit.Case
+
+  test "#find_term: returns the nth term in a sequence" do
+    assert Sequence.find_term(1, 0, 1) == 0
+    assert Sequence.find_term(2, 0, 1) == 1
+    assert Sequence.find_term(3, 0, 1) == 2
+
+    assert Sequence.find_term(1, 1, 1) == 1
+    assert Sequence.find_term(2, 1, 1) == 2
+    assert Sequence.find_term(3, 1, 1) == 3
+  end
+
+  test "#finite_lazy: is a lazy finite sequence with n terms " <>
+       "within a defined range" do
+    assert Enum.to_list(Sequence.finite_lazy(1, 1, 1)) == [1]
+    assert Enum.to_list(Sequence.finite_lazy(2, 1, 2)) == [1, 2]
+    assert Enum.to_list(Sequence.finite_lazy(4, 1, 4)) == [1, 2, 3, 4]
+
+    assert Enum.to_list(Sequence.finite_lazy(3, -1.5, 1.5)) == [-1.5, 0.0, 1.5]
+
+    floater = Enum.to_list(Sequence.finite_lazy(16, -1.5, 1.5))
+    assert floater |> List.first == -1.5
+    assert floater |> List.last == 1.5
+    assert floater |> Enum.count == 16
+
+    big_floater = Enum.to_list(Sequence.finite_lazy(800, -1.5, 1.5))
+    assert big_floater |> List.first == -1.5
+    assert big_floater |> List.last == 1.5
+    assert big_floater |> Enum.count == 800
+  end
+end


### PR DESCRIPTION
## Summary

This PR introduces a module with functions to determine if a given complex value,  (usually denoted as `C`), is a member of the Mandelbrot set. 

The key function is `count_iterations`; it returns the number of iterations of a special calculation (`f(Z): Z^2 + C` I'm referring to this as "the polynomial" for lack of a more specific name) are needed to prove whether `c` is a member of the Mandelbrot set, up to a maximum of `max_iterations`. Basically if the output of the calculation ever exceeds 2 it not part of the set, but we could search forever for some values so we limit the search to `max_iterations`.

An example from my tests:

``` elixir
not_in_the_set = Complex.new(1, 0)
in_the_set = Complex.new(-1, 0)

assert MandelbrotSet.count_iterations(not_in_the_set, 100) == 3
assert MandelbrotSet.count_iterations(in_the_set, 100) == 100
```
## Background information
- https://en.wikipedia.org/wiki/Mandelbrot_set
- http://stackoverflow.com/questions/425953/how-to-program-a-fractal
## Generating docs

I added support for doc comments.

```
mix deps.get
mix docs
open doc/index.html
```
## Further work
- Add [typespecs](http://elixir-lang.org/getting-started/typespecs-and-behaviours.html)
- Build something that iterates across the pixels of an image, translates them to the "complex plane", then for each value in the complex plane work out if it is in the Mandelbrot set.
- Translate the iteration counts of each number to a colour value using a colour ramp.
- Output an image.
