### PR TITLE
Add typespecs to Sequence, MandelbrotSet and Complex

### DIFF
--- a/lib/complex.ex
+++ b/lib/complex.ex
@@ -2,26 +2,39 @@ defmodule Complex do
   @moduledoc """
   A simple attempt at complex numbers
   """
+
+  @typedoc """
+  A structure that represents a complex number.
+
+  * `re` - represents the *real* part
+  * `im` - represents the *imaginary* part
+  """
+  @type t :: %__MODULE__{re: number, im: number}
   defstruct re: 0, im: 0
 
+  @spec new(number, number) :: t
   def new(re, im) when is_number(re) and is_number(im) do
     %__MODULE__{re: re, im: im}
   end
 
+  @spec add(t, t) :: t
   def add(a = %__MODULE__{}, b = %__MODULE__{}) do
     new(a.re + b.re, a.im + b.im)
   end
 
+  @spec subtract(t, t) :: t
   def subtract(a = %__MODULE__{}, b = %__MODULE__{}) do
     new(a.re - b.re, a.im - b.im)
   end
 
+  @spec multiply(t, t) :: t
   def multiply(a = %__MODULE__{}, b = %__MODULE__{}) do
     re = (a.re * b.re) + (a.im * b.im * -1)
     im = (a.re * b.im) + (b.re * a.im)
     new(re, im)
   end
 
+  @spec mod(t) :: float
   def mod(a = %__MODULE__{}) do
     :math.sqrt(a.re * a.re + a.im * a.im)
   end

--- a/lib/mandelbrot_set.ex
+++ b/lib/mandelbrot_set.ex
@@ -9,11 +9,23 @@ defmodule MandelbrotSet do
   * http://stackoverflow.com/questions/425953/how-to-program-a-fractal
   """
 
+  @typedoc """
+  An integer value representing the number of repeats of the core calculation
+  """
+  @type iteration_count :: integer
+  @typedoc """
+  A predicate used to stop iteration.
+
+  Returns false to continue iteration, returns true to stop.
+  """
+  @type iteration_stop_function :: (Complex.t, iteration_count -> boolean)
+
   @doc """
   Given a complex number `c`, returns the number of iterations needed to prove
   whether it is a member of the Mandelbrot set, up to a maximum of
   `max_iterations`.
   """
+  @spec count_iterations(Complex.t, integer) :: iteration_count
   def count_iterations(c, max_iterations) do
     should_stop? = fn (z, iteration_count) ->
       iteration_count >= max_iterations or unbounded?(z)
@@ -26,6 +38,7 @@ defmodule MandelbrotSet do
   Implements the complex quadratic polynomial that is at the heart of the
   Mandelbrot set: `f(Z): Z^2 + C`
   """
+  @spec apply_polynomial(Complex.t, Complex.t) :: Complex.t
   def apply_polynomial(z, c) do
     z_squared = Complex.multiply(z, z)
     Complex.add(z_squared, c)
@@ -40,6 +53,7 @@ defmodule MandelbrotSet do
   It returns the number of iterations reached before `f_stop_iterating`
   returned true.
   """
+  @spec iterate_until(Complex.t, iteration_stop_function) :: iteration_count
   def iterate_until(c, f_stop_iterating) do
     do_iterate_until(c, Complex.new(0.0, 0.0), 0, f_stop_iterating)
   end
@@ -61,6 +75,7 @@ defmodule MandelbrotSet do
   unbounded and will tend towards infinity. Numbers within the Mandelbrot set
   tend towards 2 as you continue to iterate, but never exceed it.
   """
+  @spec unbounded?(Complex.t) :: boolean
   def unbounded?(z) do
     Complex.mod(z) > 2
   end

--- a/lib/sequence.ex
+++ b/lib/sequence.ex
@@ -3,16 +3,19 @@ defmodule Sequence do
   Streamable arithmetic sequences
   """
 
+  @spec find_term(integer, number, number) :: number
   def find_term(term_to_find, first_term, common_difference) do
     first_term + (term_to_find - 1) * common_difference
   end
 
+  @spec finite_lazy(pos_integer, number, number) :: Stream.t
   def finite_lazy(num_terms, first_term, last_term) do
     common_difference = common_difference(num_terms, first_term, last_term)
     f = &(Sequence.find_term(&1, first_term, common_difference))
     Stream.map(1..num_terms, f)
   end
 
+  @spec common_difference(pos_integer, number, number) :: number
   defp common_difference(1, first_term, last_term), do: last_term - first_term
   defp common_difference(num_terms, first_term, last_term) do
     (last_term - first_term) / (num_terms - 1)

--- a/lib/sequence.ex
+++ b/lib/sequence.ex
@@ -8,7 +8,7 @@ defmodule Sequence do
     first_term + (term_to_find - 1) * common_difference
   end
 
-  @spec finite_lazy(pos_integer, number, number) :: Stream.t
+  @spec finite_lazy(pos_integer, number, number) :: Enumerable.t
   def finite_lazy(num_terms, first_term, last_term) do
     common_difference = common_difference(num_terms, first_term, last_term)
     f = &(Sequence.find_term(&1, first_term, common_difference))


### PR DESCRIPTION
# TL;DR

Add typespecs and run dialyzer in order to:
- Find bugs your tests might not
- Give a little extra information to developers reading your code for understanding 
# What?

My first time using typespecs in Elixir.

There are Mix plugins that make it easier to do this, but I opted for the manual approach this time with the hope of learning more.
# Why?

Elixir itself doesn't do anything with the information added by the typespecs. However beyond just being extra documentation, they make it possible to do **static analysis of your code**.

You can use the [Dialyzer](http://www.erlang.org/doc/apps/dialyzer/dialyzer_chapter.html) tool (bundled with Erlang) to actually validate your code with the specs you add.

This provides potential to find certain kinds of issues that your tests might not tease out. E.g. weeding out dead or unreachable code, unnecessary tests, etc

See the [Dialyzer docs](http://www.erlang.org/doc/man/dialyzer.html) for more info. 
# Annotating the code

I'll not go into detail here, it's well documented. I found these links useful:
- [Elixir Typespecs Guide](http://elixir-lang.org/getting-started/typespecs-and-behaviours.html) - Gets you started
- [Elixir API Docs Page on Typespecs](http://elixir-lang.org/docs/stable/elixir/typespecs.html) -This one lists the available built-in type names you can use
# Validating the code
## Step 1: create a PST file for Dialyzer

Dialyzer supports creation of a PST (Persistent Lookup Table) file to cache the results of analysing the Erlang/Elixir libraries so you don't have to wait while it does this every time you analyse your own code.

First create the file and by analysing Erlang's libraries:

```
$ dialyzer --build_plt --apps erts kernel stdlib crypto public_key
  Compiling some key modules to native code... done in 0m33.06s
  Creating PLT /Users/danm/.dialyzer_plt ...
Unknown functions:
  asn1rt_nif:decode_ber_tlv/1
  asn1rt_nif:encode_ber_tlv/1
  compile:file/2
  compile:forms/2
  compile:noenv_forms/2
  compile:output_generated/1
Unknown types:
  compile:option/0
 done in 1m6.38s
done (passed successfully)
```

On my machine this took under a minute to run and outputs to `~/.dialyzer_plt` by default. At this point the file is 780Kb.

Next I added the Elixir libraries:

```
$ dialyzer --add_to_plt --plt ~/.dialyzer_plt -r /usr/local/Cellar/elixir/1.2.0/lib
```

At this point the PLT file grows to 1.0MB.
## Step 2: analyse the code

First, compile the project so there is some code to analyse:

```
$ mix compile
```

Then run the analysis by executing dialyzer passing the path to folder that contains your code's compiled binary beam files:

```
$ dialyzer _build/dev/lib/mandelbrot/ebin/
  Checking whether the PLT /Users/danm/.dialyzer_plt is up-to-date... yes
  Proceeding with analysis...
sequence.ex:11: Invalid type specification for function 'Elixir.Sequence':finite_lazy/3. The success typing is (pos_integer(),number(),number()) -> #{}
 done in 0m1.05s
done (warnings were emitted)
```

---

**UPDATE** actually considering we want Dialyzer to look at our test code too, I'm assuming we should run it like:

```
$ mix test && dialyzer _build/test/lib/mandelbrot/ebin/
```

... although I've yet to find a way to break the tests from Dialyzer's perspective so I'm not sure it's actually looking at them yet.

---
## Step 3: interpret and apply fixes for warnings

At the end of the previous step in my example, this warning was output:

> sequence.ex:11: Invalid type specification for function 'Elixir.Sequence':finite_lazy/3. The success typing is (pos_integer(),number(),number()) -> #{}

The signature for the offending function looks like:

``` elixir
@spec finite_lazy(pos_integer, number, number) :: Stream.t
```

We don't strictly need the parantheses `()` after each type name, so the issue here seems to be about the return type. I've said I expect it to return a `Stream.t` because the last call in the function is to `Stream.map`. But I must have guessed wrongly. It's saying if I change the type to be a `map` it will work.

At this point I should say, remember: **any fixes suggested by the output will be in Erlang syntax!!!!**. So I cannot simply change it to:

``` elixir
# WRONG, Erlang literal syntax for a map
@spec finite_lazy(pos_integer, number, number) :: #{}

# CORRECT, Elixir literal syntax
@spec finite_lazy(pos_integer, number, number) :: %{}
```

So I replace `Stream.t` with `%{}` and recompile (**IMPORTANT** recompile. So many times I have made changes and just re-ran dialyzer only to be frustrated there is no change. It runs on your beam files so remember to `mix compile` after any change). Success, this does indeed make the warning go away.

However, saying it returns a map is a bit of a cop out. The map is the underlying type returned, so it is strictly correct because it's the most generic thing that can be said about the return type. But this communicates very little to developers reading for understanding (and possibly not enough to help dialyzer strongly enforce usage of the return type, although I'm not experienced enough with it yet to know).

I had assumed that because there was a [`Stream.t` defined](https://github.com/elixir-lang/elixir/blob/v1.2.0/lib/elixir/lib/stream.ex#L99), that this is the type that best communicated what was returned from `Stream.map`. But it seems I was wrong. Looking at the [docs for `Stream.map`](http://elixir-lang.org/docs/stable/elixir/Stream.html#map/2), it says it returns an `Enumerable.t`. So I update my code to the following:

``` elixir
@spec finite_lazy(pos_integer, number, number) :: Enumerable.t
```

A quick recompile and rerun of dialyzer confirms that this is correct.

```
$ mix compile && dialyzer _build/dev/lib/mandelbrot/ebin/
Compiled lib/sequence.ex
  Checking whether the PLT /Users/danm/.dialyzer_plt is up-to-date... yes
  Proceeding with analysis... done in 0m1.02s
done (passed successfully)
```
